### PR TITLE
feat: Add allowRegistration setting

### DIFF
--- a/client/src/api/Exceptions/BadRequestException.ts
+++ b/client/src/api/Exceptions/BadRequestException.ts
@@ -1,13 +1,8 @@
 import { HttpException } from '@slink/api/Exceptions/HttpException';
 
 export class BadRequestException extends HttpException {
-  constructor(Response: {
-    error: {
-      message: string;
-      title: string;
-    };
-  }) {
-    const message = Response?.error?.message || 'Bad Request';
+  constructor(response: { message: string; title: string }) {
+    const message = response?.message || 'Bad Request';
     super(message, 400);
   }
 }

--- a/client/src/api/Exceptions/HttpException.ts
+++ b/client/src/api/Exceptions/HttpException.ts
@@ -14,6 +14,6 @@ export abstract class HttpException extends Error {
 
   // ToDo: generate type safe error list
   get errors(): ErrorList {
-    return { error: this.message };
+    return { message: this.message };
   }
 }

--- a/client/src/lib/settings/Type/UserSettings.ts
+++ b/client/src/lib/settings/Type/UserSettings.ts
@@ -1,4 +1,5 @@
 export type UserSettings = {
+  allowRegistration: boolean;
   allowUnauthenticatedAccess: boolean;
   approvalRequired: boolean;
   password: {

--- a/client/src/routes/admin/settings/+page.svelte
+++ b/client/src/routes/admin/settings/+page.svelte
@@ -79,94 +79,113 @@
       {/snippet}
 
       <SettingItem
-        defaultValue={defaultSettings.user?.approvalRequired}
+        defaultValue={defaultSettings.user?.allowRegistration}
         reset={(value) => {
-          settings.user.approvalRequired = value;
+          settings.user.allowRegistration = value;
         }}
       >
         {#snippet label()}
-          User Approval
+          User Signup Enabled
         {/snippet}
         {#snippet hint()}
-          Toggle whether users need to be approved before they can access the
-          application
+          Toggle whether users are able to create a new account
         {/snippet}
         <Toggle
-          name="approvalRequired"
-          bind:checked={settings.user.approvalRequired}
+          name="allowRegistration"
+          bind:checked={settings.user.allowRegistration}
         />
       </SettingItem>
-      <SettingItem
-        defaultValue={defaultSettings.user?.allowUnauthenticatedAccess}
-        reset={(value) => {
-          settings.user.allowUnauthenticatedAccess = value;
-        }}
-      >
-        {#snippet label()}
-          Unauthenticated Access
-        {/snippet}
-        {#snippet hint()}
-          Toggle whether users can access the application without being
-          authenticated
-        {/snippet}
-        <Toggle
-          name="allowUnauthenticatedAccess"
-          bind:checked={settings.user.allowUnauthenticatedAccess}
-        />
-      </SettingItem>
-      <SettingItem
-        defaultValue={defaultSettings.user?.password.minLength}
-        reset={(value) => {
-          settings.user.password.minLength = value;
-        }}
-      >
-        {#snippet label()}
-          Password Length
-        {/snippet}
-        {#snippet hint()}
-          Set the minimum length of a user's password
-        {/snippet}
-        <NumberInput
-          error={$error?.errors.password?.minLength}
-          name="passwordLength"
-          bind:value={settings.user.password.minLength}
-        />
-      </SettingItem>
-      <SettingItem
-        defaultValue={defaultSettings.user?.password.requirements}
-        reset={(value) => {
-          settings.user.password.requirements = value;
-        }}
-      >
-        {#snippet label()}
-          Password Complexity
-        {/snippet}
-        {#snippet hint()}
-          Select the required character types for a user's password
-        {/snippet}
-        <Multiselect
-          type="bitmask"
-          name="passwordRequirements"
-          bind:value={settings.user.password.requirements}
+      {#if settings.user.allowRegistration}
+        <SettingItem
+          defaultValue={defaultSettings.user?.approvalRequired}
+          reset={(value) => {
+            settings.user.approvalRequired = value;
+          }}
         >
-          <MultiselectItem key="1">
-            <Icon icon="ph:number-nine-thin" />
-            Numbers
-          </MultiselectItem>
-          <MultiselectItem key="2">
-            <Icon icon="material-symbols-light:lowercase-rounded" />
-            Lowercase Letters
-          </MultiselectItem>
-          <MultiselectItem key="4">
-            <Icon icon="material-symbols-light:uppercase-rounded" />
-            Uppercase Letters
-          </MultiselectItem>
-          <MultiselectItem key="8">
-            <Icon icon="material-symbols-light:asterisk-rounded" />
-            Special Characters
-          </MultiselectItem>
-        </Multiselect>
-      </SettingItem>
+          {#snippet label()}
+            User Approval
+          {/snippet}
+          {#snippet hint()}
+            Toggle whether users need to be approved before they can access the
+            application
+          {/snippet}
+          <Toggle
+            name="approvalRequired"
+            bind:checked={settings.user.approvalRequired}
+          />
+        </SettingItem>
+        <SettingItem
+          defaultValue={defaultSettings.user?.allowUnauthenticatedAccess}
+          reset={(value) => {
+            settings.user.allowUnauthenticatedAccess = value;
+          }}
+        >
+          {#snippet label()}
+            Unauthenticated Access
+          {/snippet}
+          {#snippet hint()}
+            Toggle whether users can access the application without being
+            authenticated
+          {/snippet}
+          <Toggle
+            name="allowUnauthenticatedAccess"
+            bind:checked={settings.user.allowUnauthenticatedAccess}
+          />
+        </SettingItem>
+        <SettingItem
+          defaultValue={defaultSettings.user?.password.minLength}
+          reset={(value) => {
+            settings.user.password.minLength = value;
+          }}
+        >
+          {#snippet label()}
+            Password Length
+          {/snippet}
+          {#snippet hint()}
+            Set the minimum length of a user's password
+          {/snippet}
+          <NumberInput
+            error={$error?.errors.password?.minLength}
+            name="passwordLength"
+            bind:value={settings.user.password.minLength}
+          />
+        </SettingItem>
+        <SettingItem
+          defaultValue={defaultSettings.user?.password.requirements}
+          reset={(value) => {
+            settings.user.password.requirements = value;
+          }}
+        >
+          {#snippet label()}
+            Password Complexity
+          {/snippet}
+          {#snippet hint()}
+            Select the required character types for a user's password
+          {/snippet}
+          <Multiselect
+            type="bitmask"
+            name="passwordRequirements"
+            bind:value={settings.user.password.requirements}
+          >
+            <MultiselectItem key="1">
+              <Icon icon="ph:number-nine-thin" />
+              Numbers
+            </MultiselectItem>
+            <MultiselectItem key="2">
+              <Icon icon="material-symbols-light:lowercase-rounded" />
+              Lowercase Letters
+            </MultiselectItem>
+            <MultiselectItem key="4">
+              <Icon icon="material-symbols-light:uppercase-rounded" />
+              Uppercase Letters
+            </MultiselectItem>
+            <MultiselectItem key="8">
+              <Icon icon="material-symbols-light:asterisk-rounded" />
+              Special Characters
+            </MultiselectItem>
+          </Multiselect>
+        </SettingItem>
+      {/if}
     </SettingsPane>
     <SettingsPane
       category="image"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,6 +11,7 @@ parameters:
         username: '%env(string:default::SMB_USERNAME)%'
         password: '%env(string:default::SMB_PASSWORD)%'
   user:
+    allowRegistration: true
     allowUnauthenticatedAccess: '%env(bool:USER_ALLOW_UNAUTHENTICATED_ACCESS)%'
     approvalRequired: '%env(bool:USER_APPROVAL_REQUIRED)%'
     password:

--- a/src/Slink/Settings/Domain/ValueObject/User/UserSettings.php
+++ b/src/Slink/Settings/Domain/ValueObject/User/UserSettings.php
@@ -10,11 +10,13 @@ use Slink\Settings\Domain\ValueObject\AbstractSettingsValueObject;
 final readonly class UserSettings extends AbstractSettingsValueObject {
   /**
    * @param bool $approvalRequired
+   * @param bool $allowRegistration
    * @param bool $allowUnauthenticatedAccess
    * @param PasswordSettings $password
    */
   private function __construct(
     private bool $approvalRequired,
+    private bool $allowRegistration,
     private bool $allowUnauthenticatedAccess,
     private PasswordSettings $password,
   ) {}
@@ -26,6 +28,7 @@ final readonly class UserSettings extends AbstractSettingsValueObject {
   public function toPayload(): array {
     return [
       'approvalRequired' => $this->approvalRequired,
+      'allowRegistration' => $this->allowRegistration,
       'allowUnauthenticatedAccess' => $this->allowUnauthenticatedAccess,
       'password' => $this->password->toPayload(),
     ];
@@ -39,6 +42,7 @@ final readonly class UserSettings extends AbstractSettingsValueObject {
   public static function fromPayload(array $payload): static {
     return new self(
       $payload['approvalRequired'] ?? true,
+      $payload['allowRegistration'] ?? true,
       $payload['allowUnauthenticatedAccess'] ?? false,
       PasswordSettings::fromPayload($payload['password'])
     );

--- a/src/Slink/Settings/Infrastructure/EventStore/Upcaster/SettingsChangedUpcaster.php
+++ b/src/Slink/Settings/Infrastructure/EventStore/Upcaster/SettingsChangedUpcaster.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Settings\Infrastructure\EventStore\Upcaster;
+
+use Slink\Settings\Domain\Event\SettingsChanged;
+use Slink\Shared\Infrastructure\Persistence\EventStore\AbstractUpcaster;
+
+class SettingsChangedUpcaster extends AbstractUpcaster {
+  
+  /**
+   * @inheritDoc
+   */
+  public function upcast(array $message): array {
+    if (!$this->isEventType($message, SettingsChanged::class)) {
+      return $message;
+    }
+    
+    if (!isset($message['payload']['allowRegistration'])) {
+      $message['payload']['allowRegistration'] = true;
+    }
+    
+    return $message;
+  }
+}

--- a/src/Slink/User/Application/Command/SignUp/SignUpHandler.php
+++ b/src/Slink/User/Application/Command/SignUp/SignUpHandler.php
@@ -10,6 +10,7 @@ use Slink\Shared\Application\Command\CommandHandlerInterface;
 use Slink\Shared\Domain\Exception\Date\DateTimeException;
 use Slink\User\Domain\Context\UserCreationContext;
 use Slink\User\Domain\Enum\UserStatus;
+use Slink\User\Domain\Exception\RegistrationIsNotAllowed;
 use Slink\User\Domain\Repository\UserStoreRepositoryInterface;
 use Slink\User\Domain\User;
 use Slink\User\Domain\ValueObject\Auth\Credentials;
@@ -34,6 +35,10 @@ final readonly class SignUpHandler implements CommandHandlerInterface {
    * @throws DateTimeException
    */
   public function __invoke(SignUpCommand $command): void {
+    if (!$this->configurationProvider->get('user.allowRegistration')) {
+      throw new RegistrationIsNotAllowed();
+    }
+    
     $username = Username::fromString($command->getUsername());
     $displayName = DisplayName::fromString($command->getUsername());
     

--- a/src/Slink/User/Domain/Exception/RegistrationIsNotAllowed.php
+++ b/src/Slink/User/Domain/Exception/RegistrationIsNotAllowed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\User\Domain\Exception;
+
+class RegistrationIsNotAllowed extends \LogicException
+{
+    public function __construct(string $message = 'Sign up is not allowed')
+    {
+        parent::__construct($message);
+    }
+}


### PR DESCRIPTION
This pull request adds a new allowRegistration settings flag, letting administrators easily enable or disable user registration.

Closes #10.