### PR TITLE
feat(history): show collections on upload history

### DIFF
--- a/services/api/src/Slink/Collection/Domain/Repository/CollectionRepositoryInterface.php
+++ b/services/api/src/Slink/Collection/Domain/Repository/CollectionRepositoryInterface.php
@@ -19,6 +19,12 @@ interface CollectionRepositoryInterface {
   public function getByUserId(string $userId, int $page, int $limit): Paginator;
 
   /**
+   * @param string[] $ids
+   * @return CollectionView[]
+   */
+  public function findByIds(array $ids): array;
+
+  /**
    * @return string[]
    */
   public function findNamesByPatternAndUser(string $baseName, string $userId): array;

--- a/services/api/src/Slink/Collection/Infrastructure/ReadModel/Repository/CollectionRepository.php
+++ b/services/api/src/Slink/Collection/Infrastructure/ReadModel/Repository/CollectionRepository.php
@@ -63,6 +63,25 @@ final class CollectionRepository extends AbstractRepository implements Collectio
     return new Paginator($qb->getQuery());
   }
 
+  /**
+   * @param string[] $ids
+   * @return CollectionView[]
+   */
+  public function findByIds(array $ids): array {
+    if ($ids === []) {
+      return [];
+    }
+
+    return $this->getEntityManager()
+      ->createQueryBuilder()
+      ->from(CollectionView::class, 'c')
+      ->select('c')
+      ->where('c.uuid IN (:ids)')
+      ->setParameter('ids', $ids)
+      ->getQuery()
+      ->getResult();
+  }
+
   public function findNamesByPatternAndUser(string $baseName, string $userId): array {
     $qb = $this->getEntityManager()
       ->createQueryBuilder()

--- a/services/api/src/Slink/Image/Infrastructure/Resource/ImageResource.php
+++ b/services/api/src/Slink/Image/Infrastructure/Resource/ImageResource.php
@@ -101,6 +101,14 @@ final class ImageResource implements ResourceInterface {
     get => $this->data->get('collections', $this->image->getUuid(), []);
   }
 
+  /**
+   * @var array<int, array{id: string, name: string}>
+   */
+  #[Groups(['collection'])]
+  public array $collections {
+    get => $this->data->get('collectionSummaries', $this->image->getUuid(), []);
+  }
+
   /** @var array<string> */
   #[Groups(['tag'])]
   public array $tags {

--- a/services/api/src/Slink/Image/Infrastructure/Resource/Provider/CollectionSummaryDataProvider.php
+++ b/services/api/src/Slink/Image/Infrastructure/Resource/Provider/CollectionSummaryDataProvider.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Image\Infrastructure\Resource\Provider;
+
+use Slink\Collection\Domain\Repository\CollectionItemRepositoryInterface;
+use Slink\Collection\Domain\Repository\CollectionRepositoryInterface;
+use Slink\Image\Application\Resource\ImageDataProviderInterface;
+use Slink\Image\Infrastructure\Resource\ImageResourceContext;
+use Slink\Shared\Application\Resource\ResourceContextInterface;
+use Slink\Shared\Domain\Enum\ResourceProviderTag;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(ResourceProviderTag::Image->value)]
+final readonly class CollectionSummaryDataProvider implements ImageDataProviderInterface {
+  public function __construct(
+    private CollectionItemRepositoryInterface $collectionItemRepository,
+    private CollectionRepositoryInterface     $collectionRepository,
+  ) {
+  }
+
+  public function getProviderKey(): string {
+    return 'collectionSummaries';
+  }
+
+  public function supports(ResourceContextInterface $context): bool {
+    return $context->hasGroup('collection') && $context instanceof ImageResourceContext;
+  }
+
+  /**
+   * @param ImageResourceContext $context
+   * @return array<string, array<int, array{id: string, name: string}>>
+   */
+  public function fetch(ResourceContextInterface $context): array {
+    $imageIds = $context->imageIds;
+
+    if (count($imageIds) === 0) {
+      return [];
+    }
+
+    $imageCollections = $this->collectionItemRepository->getCollectionIdsByImageIds($imageIds);
+
+    if (count($imageCollections) === 0) {
+      return [];
+    }
+
+    $collectionIdSet = [];
+    foreach ($imageCollections as $collectionIds) {
+      foreach ($collectionIds as $collectionId) {
+        $collectionIdSet[$collectionId] = true;
+      }
+    }
+
+    $collectionIds = array_keys($collectionIdSet);
+
+    if (count($collectionIds) === 0) {
+      return [];
+    }
+
+    $collections = $this->collectionRepository->findByIds($collectionIds);
+    $collectionMap = [];
+
+    foreach ($collections as $collection) {
+      $collectionMap[$collection->getId()] = [
+        'id' => $collection->getId(),
+        'name' => $collection->getName(),
+      ];
+    }
+
+    $result = [];
+    foreach ($imageCollections as $imageId => $collectionIdsForImage) {
+      $result[$imageId] = [];
+
+      foreach ($collectionIdsForImage as $collectionId) {
+        if (isset($collectionMap[$collectionId])) {
+          $result[$imageId][] = $collectionMap[$collectionId];
+        }
+      }
+    }
+
+    return $result;
+  }
+}

--- a/services/client/src/api/Response/Image/ImageListingResponse.ts
+++ b/services/client/src/api/Response/Image/ImageListingResponse.ts
@@ -37,6 +37,7 @@ export type ImageListingItem = {
   bookmarkCount: number;
   isBookmarked?: boolean;
   collectionIds?: string[];
+  collections?: Array<{ id: string; name: string }>;
   tags?: Tag[];
 };
 

--- a/services/client/src/feature/Collection/ImageCollectionList/ImageCollectionList.svelte
+++ b/services/client/src/feature/Collection/ImageCollectionList/ImageCollectionList.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import Badge from '@slink/feature/Text/Badge/Badge.svelte';
+
+  import Icon from '@iconify/svelte';
+
+  import { routes } from '@slink/lib/utils/url/routes';
+
+  interface CollectionSummary {
+    id: string;
+    name: string;
+  }
+
+  interface Props {
+    collections?: CollectionSummary[];
+    class?: string;
+  }
+
+  let { collections = [], class: className = '' }: Props = $props();
+</script>
+
+{#if collections.length > 0}
+  <div class="flex flex-wrap gap-2 {className}">
+    {#each collections as collection (collection.id)}
+      <a
+        href={routes.collection.detail(collection.id)}
+        class="inline-flex"
+        title={collection.name}
+      >
+        <Badge variant="neon" size="sm" class="shrink-0">
+          <div class="flex items-center gap-1.5">
+            <Icon icon="ph:folder" class="h-3 w-3" />
+            <span class="font-medium truncate max-w-[10rem]">
+              {collection.name}
+            </span>
+          </div>
+        </Badge>
+      </a>
+    {/each}
+  </div>
+{/if}

--- a/services/client/src/feature/Collection/ImageCollectionList/index.ts
+++ b/services/client/src/feature/Collection/ImageCollectionList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ImageCollectionList.svelte';

--- a/services/client/src/feature/Collection/index.ts
+++ b/services/client/src/feature/Collection/index.ts
@@ -9,6 +9,7 @@ export * from './CollectionPicker/CollectionPicker.theme';
 export { default as CreateCollectionDialog } from './CreateCollectionDialog.svelte';
 export { default as CreateCollectionForm } from './CreateCollectionForm.svelte';
 export { default as CreateCollectionModal } from './CreateCollectionModal.svelte';
+export { default as ImageCollectionList } from './ImageCollectionList/ImageCollectionList.svelte';
 export { default as ImageCollectionManager } from './ImageCollectionManager/ImageCollectionManager.svelte';
 export { default as RemoveFromCollectionPopover } from './RemoveFromCollectionPopover/RemoveFromCollectionPopover.svelte';
 export { default as ShareCollectionPopover } from './ShareCollectionPopover/ShareCollectionPopover.svelte';

--- a/services/client/src/feature/Image/History/HistoryGridView.svelte
+++ b/services/client/src/feature/Image/History/HistoryGridView.svelte
@@ -8,6 +8,7 @@
   import { calculateHistoryCardWeight } from '@slink/feature/Image/utils/calculateHistoryCardWeight';
   import { Masonry } from '@slink/feature/Layout';
   import { ImageTagList } from '@slink/feature/Tag';
+  import { ImageCollectionList } from '@slink/feature/Collection';
   import { OverlayCheckbox } from '@slink/ui/components/checkbox';
 
   import { fade, fly } from 'svelte/transition';
@@ -138,14 +139,22 @@
           <ImageMetadata {item} gap="sm" />
         </div>
 
-        {#if item.tags && item.tags.length > 0}
-          <ImageTagList
-            imageId={item.id}
-            variant="neon"
-            showImageCount={false}
-            removable={false}
-            initialTags={item.tags}
-          />
+        {#if (item.collections && item.collections.length > 0) || (item.tags && item.tags.length > 0)}
+          <div class="space-y-2">
+            {#if item.collections && item.collections.length > 0}
+              <ImageCollectionList collections={item.collections} />
+            {/if}
+
+            {#if item.tags && item.tags.length > 0}
+              <ImageTagList
+                imageId={item.id}
+                variant="neon"
+                showImageCount={false}
+                removable={false}
+                initialTags={item.tags}
+              />
+            {/if}
+          </div>
         {/if}
       </div>
     </article>

--- a/services/client/src/feature/Image/History/HistoryListView.svelte
+++ b/services/client/src/feature/Image/History/HistoryListView.svelte
@@ -5,6 +5,7 @@
     ViewCountBadge,
     VisibilityBadge,
   } from '@slink/feature/Image';
+  import { ImageCollectionList } from '@slink/feature/Collection';
   import { ImageTagList } from '@slink/feature/Tag';
   import { FormattedDate } from '@slink/feature/Text';
   import { OverlayCheckbox } from '@slink/ui/components/checkbox';
@@ -137,15 +138,21 @@
             <ImageMetadata {item} gap="md" />
           </div>
 
-          {#if item.tags && item.tags.length > 0}
-            <div class="mt-auto">
-              <ImageTagList
-                imageId={item.id}
-                variant="neon"
-                showImageCount={false}
-                removable={false}
-                initialTags={item.tags}
-              />
+          {#if (item.collections && item.collections.length > 0) || (item.tags && item.tags.length > 0)}
+            <div class="mt-auto space-y-2">
+              {#if item.collections && item.collections.length > 0}
+                <ImageCollectionList collections={item.collections} />
+              {/if}
+
+              {#if item.tags && item.tags.length > 0}
+                <ImageTagList
+                  imageId={item.id}
+                  variant="neon"
+                  showImageCount={false}
+                  removable={false}
+                  initialTags={item.tags}
+                />
+              {/if}
             </div>
           {:else}
             <div


### PR DESCRIPTION
#140 

  - Adds collection summaries to history API response and includes collection names in image listing data.
  - Adds a reusable ImageCollectionList component and renders collection chips (folder icon + name) in history grid/list cards.
  - Collection chip links to the collection detail page.