### PR TITLE
feat(collections): add collection search selector

### DIFF
--- a/services/client/src/feature/Collection/CollectionSelector/CollectionSelector.svelte
+++ b/services/client/src/feature/Collection/CollectionSelector/CollectionSelector.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import {
+    collectionSelectorContainerVariants,
+    collectionSelectorIconContainerVariants,
+    collectionSelectorIconVariants,
+    collectionSelectorInputVariants,
+    type CollectionSelectorContainerVariants,
+  } from '@slink/feature/Collection/CollectionSelector/CollectionSelector.theme';
+  import Badge from '@slink/feature/Text/Badge/Badge.svelte';
+  import { Popover } from 'bits-ui';
+
+  import Icon from '@iconify/svelte';
+
+  import type { CollectionResponse } from '@slink/api/Response';
+
+  import { cn } from '@slink/utils/ui';
+
+  interface Props extends CollectionSelectorContainerVariants {
+    collections: CollectionResponse[];
+    selectedCollections?: CollectionResponse[];
+    onCollectionsChange?: (collections: CollectionResponse[]) => void;
+    placeholder?: string;
+  }
+
+  let {
+    collections,
+    selectedCollections = [],
+    onCollectionsChange,
+    disabled = false,
+    placeholder = 'Search and select collections',
+    variant = 'neon',
+  }: Props = $props();
+
+  let isOpen = $state(false);
+  let searchTerm = $state('');
+  let inputRef = $state<HTMLInputElement>();
+
+  const selectedIds = $derived(new Set(selectedCollections.map((c) => c.id)));
+  const hasSelected = $derived(selectedCollections.length > 0);
+  const hasQuery = $derived(Boolean(searchTerm.trim()));
+
+  const filteredCollections = $derived(
+    collections.filter(
+      (collection) =>
+        !selectedIds.has(collection.id) &&
+        collection.name.toLowerCase().includes(searchTerm.toLowerCase()),
+    ),
+  );
+
+  const handleContainerClick = () => {
+    if (disabled) return;
+    inputRef?.focus();
+    if (hasQuery) {
+      isOpen = true;
+    }
+  };
+
+  const handleContainerKeydown = (e: KeyboardEvent) => {
+    if (disabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      inputRef?.focus();
+      if (hasQuery) {
+        isOpen = true;
+      }
+    }
+  };
+
+  const addCollection = (collection: CollectionResponse) => {
+    if (disabled || selectedIds.has(collection.id)) return;
+    onCollectionsChange?.([...selectedCollections, collection]);
+    searchTerm = '';
+    isOpen = false;
+  };
+
+  const removeCollection = (collectionId: string) => {
+    if (disabled) return;
+    onCollectionsChange?.(
+      selectedCollections.filter((collection) => collection.id !== collectionId),
+    );
+  };
+
+  $effect(() => {
+    if (disabled) {
+      isOpen = false;
+      return;
+    }
+
+    if (hasQuery) {
+      isOpen = true;
+    } else {
+      isOpen = false;
+    }
+  });
+</script>
+
+<div class="space-y-3">
+  <div class="relative">
+    <Popover.Root bind:open={isOpen}>
+      <Popover.Trigger disabled={true}>
+        {#snippet child({ props })}
+          <div
+            {...props}
+            class={cn(
+              collectionSelectorContainerVariants({
+                variant,
+                disabled,
+              }),
+            )}
+            role="combobox"
+            aria-expanded={!disabled && isOpen}
+            aria-controls="collection-dropdown"
+            aria-disabled={disabled}
+            tabindex={disabled ? -1 : 0}
+            onkeydown={handleContainerKeydown}
+            onclick={handleContainerClick}
+          >
+            <div class="flex items-center gap-3 relative z-10">
+              <div class="shrink-0">
+                <div class={collectionSelectorIconContainerVariants({ variant })}>
+                  <Icon
+                    icon="ph:folder"
+                    class={collectionSelectorIconVariants({ variant })}
+                  />
+                </div>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-1.5 flex-1">
+                {#each selectedCollections as collection (collection.id)}
+                  <Badge variant="neon" size="sm" class="shrink-0">
+                    <div class="flex items-center gap-1.5">
+                      <Icon icon="ph:folder" class="h-3 w-3" />
+                      <span class="font-medium truncate max-w-[10rem]">
+                        {collection.name}
+                      </span>
+                      <button
+                        type="button"
+                        class="ml-1 rounded p-0.5 text-blue-600 hover:text-blue-700 hover:bg-blue-100/60 dark:text-blue-300 dark:hover:text-blue-200 dark:hover:bg-blue-500/20 transition-colors"
+                        aria-label="Remove {collection.name} collection"
+                        onclick={() => removeCollection(collection.id)}
+                      >
+                        <Icon icon="ph:x" class="h-2.5 w-2.5" />
+                      </button>
+                    </div>
+                  </Badge>
+                {/each}
+
+                <div class="flex-1 min-w-30">
+                  <input
+                    bind:this={inputRef}
+                    bind:value={searchTerm}
+                    class={collectionSelectorInputVariants({ variant, disabled })}
+                    placeholder={hasSelected
+                      ? 'Add more collections...'
+                      : placeholder}
+                    {disabled}
+                    autocomplete="off"
+                    onfocus={() => {
+                      if (!disabled && hasQuery) {
+                        isOpen = true;
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        {/snippet}
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content
+          class="z-50 w-[var(--bits-popover-anchor-width)] bg-white dark:bg-gray-900/95 backdrop-blur-md border border-gray-200/60 dark:border-white/10 rounded-lg shadow-2xl shadow-gray-500/5 dark:shadow-black/50 ring-1 ring-gray-100/20 dark:ring-white/5 p-1"
+          sideOffset={6}
+          align="start"
+          trapFocus={false}
+          interactOutsideBehavior="close"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={() => (isOpen = false)}
+          onFocusOutside={() => (isOpen = false)}
+          onEscapeKeydown={() => (isOpen = false)}
+        >
+          <div class="max-h-60 overflow-y-auto py-1">
+            {#if filteredCollections.length === 0}
+              <div class="px-4 py-6 text-center text-sm text-gray-500 dark:text-white/50">
+                No collections found
+              </div>
+            {:else}
+              {#each filteredCollections as collection (collection.id)}
+                <button
+                  type="button"
+                  class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-blue-50/60 dark:hover:bg-blue-500/10 transition-colors text-left"
+                  onclick={() => addCollection(collection)}
+                >
+                  <Icon icon="ph:folder" class="h-4 w-4 text-blue-500" />
+                  <span class="truncate">{collection.name}</span>
+                </button>
+              {/each}
+            {/if}
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  </div>
+</div>

--- a/services/client/src/feature/Collection/CollectionSelector/CollectionSelector.theme.ts
+++ b/services/client/src/feature/Collection/CollectionSelector/CollectionSelector.theme.ts
@@ -1,0 +1,144 @@
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
+
+export const collectionSelectorContainerVariants = cva(
+  'min-h-[2.75rem] w-full px-3 py-2 rounded-lg transition-colors duration-200',
+  {
+    variants: {
+      variant: {
+        default: [
+          'bg-white dark:bg-gray-900/60',
+          'backdrop-blur-sm',
+          'border border-gray-200/80 dark:border-white/10',
+          'hover:bg-gray-50 dark:hover:bg-gray-900/70',
+          'focus-within:border-gray-300 dark:focus-within:border-white/20',
+          'focus-within:bg-white dark:focus-within:bg-gray-900/80',
+        ],
+        neon: [
+          'bg-white dark:bg-gray-900/60',
+          'backdrop-blur-sm',
+          'border border-gray-200/60 dark:border-white/10',
+          'shadow-sm transition-all duration-300',
+          'hover:border-blue-300/40 dark:hover:border-blue-500/25',
+          'hover:shadow-sm hover:shadow-blue-200/20 dark:hover:shadow-blue-900/10',
+          'hover:bg-blue-50/15 dark:hover:bg-blue-500/6',
+          'focus-within:border-blue-400/60 dark:focus-within:border-blue-500/40',
+          'focus-within:shadow-md focus-within:shadow-blue-200/30 dark:focus-within:shadow-blue-900/20',
+          'focus-within:bg-blue-50/25 dark:focus-within:bg-blue-500/10',
+          'focus-within:ring-1 focus-within:ring-blue-300/20 dark:focus-within:ring-blue-500/15',
+        ],
+        minimal: [
+          'bg-white dark:bg-gray-900/60',
+          'backdrop-blur-sm',
+          'border border-gray-200/60 dark:border-white/10',
+          'hover:bg-gray-50/80 dark:hover:bg-gray-900/70',
+          'focus-within:border-gray-300/80 dark:focus-within:border-white/20',
+        ],
+        subtle: [
+          'bg-gray-50/50 dark:bg-gray-900/60',
+          'backdrop-blur-sm',
+          'border border-gray-200/60 dark:border-white/8',
+          'hover:bg-gray-100/50 dark:hover:bg-gray-900/70',
+          'focus-within:border-gray-300 dark:focus-within:border-white/15',
+          'focus-within:bg-white dark:focus-within:bg-gray-900/80',
+        ],
+      },
+      disabled: {
+        true: 'opacity-50 cursor-not-allowed',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      disabled: false,
+    },
+  },
+);
+
+export const collectionSelectorIconContainerVariants = cva(
+  'w-7 h-7 rounded-lg flex items-center justify-center',
+  {
+    variants: {
+      variant: {
+        default: [
+          'bg-gray-100 dark:bg-white/10',
+          'text-gray-500 dark:text-white/60',
+        ],
+        neon: [
+          'bg-blue-50 dark:bg-blue-500/20',
+          'border border-blue-200/50 dark:border-blue-500/30',
+          'text-blue-600 dark:text-blue-400',
+        ],
+        minimal: [
+          'bg-gray-100/80 dark:bg-white/10',
+          'text-gray-500 dark:text-white/60',
+        ],
+        subtle: ['bg-transparent', 'text-gray-400 dark:text-white/50'],
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export const collectionSelectorIconVariants = cva(
+  'h-3.5 w-3.5 transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'text-gray-500 dark:text-white/60',
+        neon: 'text-blue-600 dark:text-blue-400',
+        minimal: 'text-gray-500 dark:text-white/60',
+        subtle: 'text-gray-400 dark:text-white/50',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export const collectionSelectorInputVariants = cva(
+  'w-full bg-transparent border-0 outline-none placeholder:text-muted-foreground resize-none',
+  {
+    variants: {
+      size: {
+        sm: 'text-xs py-1',
+        md: 'text-sm py-2',
+        lg: 'text-base py-3',
+      },
+      variant: {
+        default:
+          'placeholder:text-gray-400 dark:placeholder:text-white/40 text-gray-700 dark:text-white transition-all duration-300',
+        neon: 'placeholder:text-gray-400 dark:placeholder:text-white/40 text-gray-700 dark:text-white transition-all duration-300',
+        minimal:
+          'placeholder:text-gray-500 dark:placeholder:text-white/40 text-gray-700 dark:text-white transition-colors duration-150',
+        subtle:
+          'placeholder:text-gray-400 dark:placeholder:text-white/40 text-gray-700 dark:text-white transition-colors duration-150',
+      },
+      disabled: {
+        true: 'opacity-50 cursor-not-allowed',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+      disabled: false,
+    },
+  },
+);
+
+export type CollectionSelectorContainerVariants = VariantProps<
+  typeof collectionSelectorContainerVariants
+>;
+export type CollectionSelectorIconContainerVariants = VariantProps<
+  typeof collectionSelectorIconContainerVariants
+>;
+export type CollectionSelectorIconVariants = VariantProps<
+  typeof collectionSelectorIconVariants
+>;
+export type CollectionSelectorInputVariants = VariantProps<
+  typeof collectionSelectorInputVariants
+>;

--- a/services/client/src/feature/Collection/CollectionSelector/index.ts
+++ b/services/client/src/feature/Collection/CollectionSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CollectionSelector.svelte';

--- a/services/client/src/feature/Collection/index.ts
+++ b/services/client/src/feature/Collection/index.ts
@@ -6,6 +6,8 @@ export { default as CollectionItemDropdown } from './CollectionItemDropdown/Coll
 export { default as CollectionListView } from './CollectionList/CollectionListView.svelte';
 export { default as CollectionPicker } from './CollectionPicker/CollectionPicker.svelte';
 export * from './CollectionPicker/CollectionPicker.theme';
+export { default as CollectionSelector } from './CollectionSelector/CollectionSelector.svelte';
+export * from './CollectionSelector/CollectionSelector.theme';
 export { default as CreateCollectionDialog } from './CreateCollectionDialog.svelte';
 export { default as CreateCollectionForm } from './CreateCollectionForm.svelte';
 export { default as CreateCollectionModal } from './CreateCollectionModal.svelte';

--- a/services/client/src/routes/collections/+page.svelte
+++ b/services/client/src/routes/collections/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { LoadMoreButton, StopPropagation } from '@slink/feature/Action';
-  import { CollectionActionsDropdown } from '@slink/feature/Collection';
-  import { CreateCollectionForm } from '@slink/feature/Collection';
+  import {
+    CollectionActionsDropdown,
+    CollectionSelector,
+    CreateCollectionForm,
+  } from '@slink/feature/Collection';
   import { EmptyState } from '@slink/feature/Layout';
   import { CollectionSkeleton } from '@slink/feature/Layout';
   import { FormattedDate } from '@slink/feature/Text';
@@ -13,6 +16,7 @@
   import { fade, fly } from 'svelte/transition';
 
   import { ValidationException } from '@slink/api/Exceptions';
+  import type { CollectionResponse } from '@slink/api/Response';
 
   import { skeleton } from '@slink/lib/actions/skeleton';
   import { useCollectionListFeed } from '@slink/lib/state/CollectionListFeed.svelte';
@@ -23,6 +27,19 @@
   let createModalOpen = $state(false);
   let createFormErrors = $state<Record<string, string>>({});
   let isCreating = $state(false);
+  let selectedCollections = $state<CollectionResponse[]>([]);
+
+  const selectedCollectionIds = $derived(
+    new Set(selectedCollections.map((collection) => collection.id)),
+  );
+
+  const visibleCollections = $derived(
+    selectedCollections.length > 0
+      ? collectionsFeed.items.filter((collection) =>
+          selectedCollectionIds.has(collection.id),
+        )
+      : collectionsFeed.items,
+  );
 
   $effect(() => {
     if (!collectionsFeed.isDirty) {
@@ -59,6 +76,10 @@
     createModalOpen = false;
     createFormErrors = {};
   }
+
+  const handleCollectionsChange = (collections: CollectionResponse[]) => {
+    selectedCollections = collections;
+  };
 </script>
 
 <svelte:head>
@@ -74,25 +95,36 @@
       showDelay: 100,
     }}
   >
-    <div class="mb-8 flex items-center justify-between">
-      <div>
-        <h1 class="text-3xl font-semibold text-slate-900 dark:text-white">
-          Collections
-        </h1>
-        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          Organize your images into albums
-        </p>
+    <div class="mb-8 space-y-6">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-3xl font-semibold text-slate-900 dark:text-white">
+            Collections
+          </h1>
+          <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Organize your images into albums
+          </p>
+        </div>
+        <Button
+          variant="glass"
+          size="sm"
+          rounded="full"
+          onclick={() => (createModalOpen = true)}
+          class="gap-2"
+        >
+          <Icon icon="lucide:plus" class="h-4 w-4" />
+          <span class="hidden sm:inline">New Collection</span>
+        </Button>
       </div>
-      <Button
-        variant="glass"
-        size="sm"
-        rounded="full"
-        onclick={() => (createModalOpen = true)}
-        class="gap-2"
-      >
-        <Icon icon="lucide:plus" class="h-4 w-4" />
-        <span class="hidden sm:inline">New Collection</span>
-      </Button>
+
+      <CollectionSelector
+        collections={collectionsFeed.items}
+        {selectedCollections}
+        onCollectionsChange={handleCollectionsChange}
+        placeholder="Search and select collections"
+        variant="neon"
+        disabled={collectionsFeed.isLoading}
+      />
     </div>
 
     {#if collectionsFeed.showSkeleton}
@@ -111,65 +143,77 @@
           actionClick={() => (createModalOpen = true)}
         />
       </div>
-    {:else if collectionsFeed.items.length > 0}
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {#each collectionsFeed.items as collection (collection.id)}
-          <div
-            in:fly={{ y: 20, duration: 300, delay: Math.random() * 100 }}
-            class="group relative overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900/60 transition-all duration-200 hover:border-gray-300 dark:hover:border-gray-700/80 hover:shadow-md dark:hover:shadow-gray-900/50"
-          >
-            <a href="/collection/{collection.id}" class="block">
-              <div
-                class="aspect-4/3 bg-gray-100 dark:bg-gray-800/50 flex items-center justify-center relative overflow-hidden"
-              >
-                <LazyImage
-                  src={collection.coverImage}
-                  alt={collection.name}
-                  class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-                  containerClass="w-full h-full"
+    {:else}
+      {#if visibleCollections.length > 0}
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {#each visibleCollections as collection (collection.id)}
+            <div
+              in:fly={{ y: 20, duration: 300, delay: Math.random() * 100 }}
+              class="group relative overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900/60 transition-all duration-200 hover:border-gray-300 dark:hover:border-gray-700/80 hover:shadow-md dark:hover:shadow-gray-900/50"
+            >
+              <a href="/collection/{collection.id}" class="block">
+                <div
+                  class="aspect-4/3 bg-gray-100 dark:bg-gray-800/50 flex items-center justify-center relative overflow-hidden"
                 >
-                  {#snippet placeholder()}
-                    <Icon
-                      icon="ph:folder-simple-duotone"
-                      class="w-12 h-12 text-gray-400 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-500 transition-colors"
-                    />
-                  {/snippet}
-                </LazyImage>
-                <div class="absolute bottom-2 left-2">
-                  <span
-                    class="flex items-center gap-1 px-2 py-1 rounded-full bg-black/40 backdrop-blur-md text-white text-xs"
+                  <LazyImage
+                    src={collection.coverImage}
+                    alt={collection.name}
+                    class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    containerClass="w-full h-full"
                   >
-                    <Icon icon="ph:images" class="w-3.5 h-3.5" />
-                    {collection.itemCount ?? 0}
-                  </span>
-                </div>
-              </div>
-            </a>
-            <div class="p-3 flex items-start justify-between gap-2">
-              <a href="/collection/{collection.id}" class="flex-1 min-w-0">
-                <h3
-                  class="font-medium text-gray-900 dark:text-white truncate text-sm"
-                >
-                  {@html collection.name}
-                </h3>
-                {#if collection.description}
-                  <p
-                    class="text-xs text-gray-500 dark:text-gray-400 mt-1 line-clamp-2"
-                  >
-                    {@html collection.description}
-                  </p>
-                {/if}
-                <div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
-                  <FormattedDate date={collection.createdAt.timestamp} />
+                    {#snippet placeholder()}
+                      <Icon
+                        icon="ph:folder-simple-duotone"
+                        class="w-12 h-12 text-gray-400 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-500 transition-colors"
+                      />
+                    {/snippet}
+                  </LazyImage>
+                  <div class="absolute bottom-2 left-2">
+                    <span
+                      class="flex items-center gap-1 px-2 py-1 rounded-full bg-black/40 backdrop-blur-md text-white text-xs"
+                    >
+                      <Icon icon="ph:images" class="w-3.5 h-3.5" />
+                      {collection.itemCount ?? 0}
+                    </span>
+                  </div>
                 </div>
               </a>
-              <StopPropagation>
-                <CollectionActionsDropdown {collection} />
-              </StopPropagation>
+              <div class="p-3 flex items-start justify-between gap-2">
+                <a href="/collection/{collection.id}" class="flex-1 min-w-0">
+                  <h3
+                    class="font-medium text-gray-900 dark:text-white truncate text-sm"
+                  >
+                    {@html collection.name}
+                  </h3>
+                  {#if collection.description}
+                    <p
+                      class="text-xs text-gray-500 dark:text-gray-400 mt-1 line-clamp-2"
+                    >
+                      {@html collection.description}
+                    </p>
+                  {/if}
+                  <div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                    <FormattedDate date={collection.createdAt.timestamp} />
+                  </div>
+                </a>
+                <StopPropagation>
+                  <CollectionActionsDropdown {collection} />
+                </StopPropagation>
+              </div>
             </div>
-          </div>
-        {/each}
-      </div>
+          {/each}
+        </div>
+      {:else}
+        <div in:fade={{ duration: 200 }}>
+          <EmptyState
+            icon="ph:folder-simple-duotone"
+            title="No collections match your selection"
+            description="Try selecting fewer collections or clear the filter."
+            variant="purple"
+            size="md"
+          />
+        </div>
+      {/if}
 
       {#if collectionsFeed.hasMore}
         <div class="flex justify-center mt-8">


### PR DESCRIPTION
https://github.com/andrii-kryvoviaz/slink/issues/143

  - Adds a collection search/select bar on /collections (same interaction pattern as Upload History).
  - Uses folder icon and “Search and select collections” placeholder.
  - Filters the grid based on selected collections.