### PR TITLE
feat(tags): add move and cascade delete

### DIFF
--- a/services/api/src/Slink/Tag/Application/Command/DeleteTag/DeleteTagHandler.php
+++ b/services/api/src/Slink/Tag/Application/Command/DeleteTag/DeleteTagHandler.php
@@ -7,11 +7,14 @@ namespace Slink\Tag\Application\Command\DeleteTag;
 use Slink\Shared\Application\Command\CommandHandlerInterface;
 use Slink\Shared\Domain\ValueObject\ID;
 use Slink\Tag\Domain\Exception\TagAccessDeniedException;
+use Slink\Tag\Domain\Repository\TagRepositoryInterface;
 use Slink\Tag\Domain\Repository\TagStoreRepositoryInterface;
+use Slink\Tag\Domain\ValueObject\TagPath;
 
 final readonly class DeleteTagHandler implements CommandHandlerInterface {
   public function __construct(
     private TagStoreRepositoryInterface $tagStore,
+    private TagRepositoryInterface $tagRepository,
   ) {
   }
 
@@ -25,7 +28,26 @@ final readonly class DeleteTagHandler implements CommandHandlerInterface {
       throw new TagAccessDeniedException();
     }
 
-    $tag->delete();
-    $this->tagStore->store($tag);
+    $tagsToDelete = $this->tagRepository->findTagsWithDescendants(
+      [$tagId->toString()],
+      $userId,
+    );
+
+    usort(
+      $tagsToDelete,
+      fn($a, $b) =>
+        TagPath::fromString($b->getPath())->getDepth()
+        <=> TagPath::fromString($a->getPath())->getDepth(),
+    );
+
+    foreach ($tagsToDelete as $tagView) {
+      $tagAggregate = $this->tagStore->get(ID::fromString($tagView->getUuid()));
+      if (!$tagAggregate->getUserId()->equals($userId)) {
+        throw new TagAccessDeniedException();
+      }
+
+      $tagAggregate->delete();
+      $this->tagStore->store($tagAggregate);
+    }
   }
 }

--- a/services/api/src/Slink/Tag/Application/Command/MoveTag/MoveTagCommand.php
+++ b/services/api/src/Slink/Tag/Application/Command/MoveTag/MoveTagCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Tag\Application\Command\MoveTag;
+
+use Slink\Shared\Application\Command\CommandInterface;
+use Slink\Shared\Infrastructure\MessageBus\EnvelopedMessage;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class MoveTagCommand implements CommandInterface {
+  use EnvelopedMessage;
+
+  public function __construct(
+    #[Assert\Uuid]
+    private ?string $parentId = null,
+  ) {
+  }
+
+  public function getParentId(): ?string {
+    return $this->parentId ?: null;
+  }
+}

--- a/services/api/src/Slink/Tag/Application/Command/MoveTag/MoveTagHandler.php
+++ b/services/api/src/Slink/Tag/Application/Command/MoveTag/MoveTagHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Tag\Application\Command\MoveTag;
+
+use Slink\Shared\Application\Command\CommandHandlerInterface;
+use Slink\Shared\Domain\ValueObject\Date\DateTime;
+use Slink\Shared\Domain\ValueObject\ID;
+use Slink\Tag\Domain\Exception\TagAccessDeniedException;
+use Slink\Tag\Domain\Exception\TagMoveNotAllowedException;
+use Slink\Tag\Domain\Repository\TagRepositoryInterface;
+use Slink\Tag\Domain\Repository\TagStoreRepositoryInterface;
+use Slink\Tag\Domain\Specification\TagDuplicateSpecificationInterface;
+use Slink\Tag\Domain\ValueObject\TagPath;
+
+final readonly class MoveTagHandler implements CommandHandlerInterface {
+  public function __construct(
+    private TagStoreRepositoryInterface        $tagStore,
+    private TagRepositoryInterface             $tagRepository,
+    private TagDuplicateSpecificationInterface $duplicateSpecification,
+  ) {
+  }
+
+  public function __invoke(MoveTagCommand $command, string $userId, string $id): void {
+    $userId = ID::fromString($userId);
+    $tagId = ID::fromString($id);
+    $parentId = $command->getParentId() ? ID::fromString($command->getParentId()) : null;
+
+    $tag = $this->tagStore->get($tagId);
+
+    if (!$tag->getUserId()->equals($userId)) {
+      throw new TagAccessDeniedException();
+    }
+
+    if ($parentId && $parentId->equals($tagId)) {
+      throw new TagMoveNotAllowedException('Tag cannot be its own parent.');
+    }
+
+    $currentPath = $tag->getPath()->getValue();
+
+    $parentPath = null;
+    if ($parentId) {
+      $parentView = $this->tagRepository->oneById($parentId);
+      if ($parentView->getUserId() !== $userId->toString()) {
+        throw new TagAccessDeniedException();
+      }
+
+      $parentPath = TagPath::fromString($parentView->getPath());
+
+      if ($parentPath->isDescendantOf($tag->getPath())) {
+        throw new TagMoveNotAllowedException('Tag cannot be moved under its descendant.');
+      }
+    }
+
+    $newPath = $parentPath
+      ? TagPath::createChild($parentPath, $tag->getName())
+      : TagPath::createRoot($tag->getName());
+
+    $isSameParent = $tag->getParentId()?->equals($parentId) ?? ($parentId === null);
+    if ($isSameParent && $currentPath === $newPath->getValue()) {
+      return;
+    }
+
+    $this->duplicateSpecification->ensureUnique($tag->getName(), $userId, $parentId);
+
+    $now = DateTime::now();
+    $tag->move($parentId, $newPath, $now);
+    $this->tagStore->store($tag);
+
+    $descendants = $this->tagRepository->findDescendantsByPaths([$currentPath], $userId);
+    if (empty($descendants)) {
+      return;
+    }
+
+    foreach ($descendants as $descendant) {
+      $descendantId = ID::fromString($descendant->getUuid());
+      $descendantTag = $this->tagStore->get($descendantId);
+
+      if (!$descendantTag->getUserId()->equals($userId)) {
+        continue;
+      }
+
+      $descendantOldPath = $descendant->getPath();
+      $suffix = substr($descendantOldPath, strlen($currentPath));
+      $newDescendantPath = $newPath->getValue() . $suffix;
+
+      $descendantTag->updatePath(TagPath::fromString($newDescendantPath), $now);
+      $this->tagStore->store($descendantTag);
+    }
+  }
+}

--- a/services/api/src/Slink/Tag/Domain/Event/TagPathWasUpdated.php
+++ b/services/api/src/Slink/Tag/Domain/Event/TagPathWasUpdated.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Tag\Domain\Event;
+
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+use Slink\Shared\Domain\Exception\Date\DateTimeException;
+use Slink\Shared\Domain\ValueObject\Date\DateTime;
+use Slink\Shared\Domain\ValueObject\ID;
+use Slink\Tag\Domain\ValueObject\TagPath;
+
+final readonly class TagPathWasUpdated implements SerializablePayload {
+  public function __construct(
+    public ID       $id,
+    public TagPath  $path,
+    public DateTime $updatedAt,
+  ) {}
+
+  /**
+   * @return array<string, string|null>
+   */
+  public function toPayload(): array {
+    return [
+      'uuid' => $this->id->toString(),
+      'path' => $this->path->getValue(),
+      'updated_at' => $this->updatedAt->toString(),
+    ];
+  }
+
+  /**
+   * @param array<string, string|null> $payload
+   * @throws DateTimeException
+   */
+  public static function fromPayload(array $payload): static {
+    return new self(
+      ID::fromString($payload['uuid'] ?? ''),
+      TagPath::fromString($payload['path'] ?? ''),
+      !empty($payload['updated_at']) ? DateTime::fromString($payload['updated_at']) : DateTime::now(),
+    );
+  }
+}

--- a/services/api/src/Slink/Tag/Domain/Event/TagWasMoved.php
+++ b/services/api/src/Slink/Tag/Domain/Event/TagWasMoved.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Tag\Domain\Event;
+
+use EventSauce\EventSourcing\Serialization\SerializablePayload;
+use Slink\Shared\Domain\Exception\Date\DateTimeException;
+use Slink\Shared\Domain\ValueObject\Date\DateTime;
+use Slink\Shared\Domain\ValueObject\ID;
+use Slink\Tag\Domain\ValueObject\TagPath;
+
+final readonly class TagWasMoved implements SerializablePayload {
+  public function __construct(
+    public ID       $id,
+    public ?ID      $parentId,
+    public TagPath  $path,
+    public DateTime $updatedAt,
+  ) {}
+
+  /**
+   * @return array<string, string|null>
+   */
+  public function toPayload(): array {
+    return [
+      'uuid' => $this->id->toString(),
+      'parent_id' => $this->parentId?->toString(),
+      'path' => $this->path->getValue(),
+      'updated_at' => $this->updatedAt->toString(),
+    ];
+  }
+
+  /**
+   * @param array<string, string|null> $payload
+   * @throws DateTimeException
+   */
+  public static function fromPayload(array $payload): static {
+    return new self(
+      ID::fromString($payload['uuid'] ?? ''),
+      !empty($payload['parent_id']) ? ID::fromString($payload['parent_id']) : null,
+      TagPath::fromString($payload['path'] ?? ''),
+      !empty($payload['updated_at']) ? DateTime::fromString($payload['updated_at']) : DateTime::now(),
+    );
+  }
+}

--- a/services/api/src/Slink/Tag/Domain/Exception/TagMoveNotAllowedException.php
+++ b/services/api/src/Slink/Tag/Domain/Exception/TagMoveNotAllowedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slink\Tag\Domain\Exception;
+
+use Slink\Shared\Domain\Exception\SpecificationException;
+
+final class TagMoveNotAllowedException extends SpecificationException {
+  public function __construct(string $message) {
+    parent::__construct($message);
+  }
+
+  public function getProperty(): string {
+    return 'parentId';
+  }
+}

--- a/services/api/src/Slink/Tag/Infrastructure/ReadModel/View/TagView.php
+++ b/services/api/src/Slink/Tag/Infrastructure/ReadModel/View/TagView.php
@@ -114,6 +114,23 @@ class TagView extends AbstractView {
     $this->parent = $parent;
   }
 
+  public function updateHierarchy(
+    string $path,
+    ?string $parentId,
+    ?TagView $parent,
+    DateTime $updatedAt,
+  ): void {
+    $this->path = $path;
+    $this->parentId = $parentId;
+    $this->parent = $parent;
+    $this->updatedAt = $updatedAt;
+  }
+
+  public function updatePath(string $path, DateTime $updatedAt): void {
+    $this->path = $path;
+    $this->updatedAt = $updatedAt;
+  }
+
   #[Groups(['public', 'private'])]
   #[SerializedName('children')]
   public function getChildren(): Collection {

--- a/services/api/src/UI/Http/Rest/Controller/Tag/MoveTagController.php
+++ b/services/api/src/UI/Http/Rest/Controller/Tag/MoveTagController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UI\Http\Rest\Controller\Tag;
+
+use Slink\Shared\Application\Command\CommandTrait;
+use Slink\Tag\Application\Command\MoveTag\MoveTagCommand;
+use Slink\User\Domain\Contracts\UserInterface;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use UI\Http\Rest\Response\ApiResponse;
+
+#[AsController]
+#[Route(path: '/tags/{id}', name: 'move_tag', methods: ['PATCH'])]
+#[IsGranted('IS_AUTHENTICATED_FULLY')]
+final readonly class MoveTagController {
+  use CommandTrait;
+
+  public function __invoke(
+    #[MapRequestPayload] MoveTagCommand $command,
+    #[CurrentUser] UserInterface $user,
+    string $id,
+  ): ApiResponse {
+    $this->handle($command->withContext([
+      'userId' => $user->getIdentifier(),
+      'id' => $id,
+    ]));
+
+    return ApiResponse::empty();
+  }
+}

--- a/services/client/src/api/Resources/TagResource.ts
+++ b/services/client/src/api/Resources/TagResource.ts
@@ -5,6 +5,7 @@ export interface Tag {
   id: string;
   name: string;
   path: string;
+  parentId?: string | null;
   isRoot: boolean;
   depth: number;
   imageCount: number;
@@ -19,8 +20,8 @@ export interface CreateTagRequest {
 }
 
 export interface UpdateTagRequest {
-  name: string;
-  parentId?: string;
+  name?: string;
+  parentId?: string | null;
 }
 
 export interface TagListRequest {
@@ -68,6 +69,10 @@ export class TagResource extends AbstractResource {
 
   async deleteTag(id: string): Promise<void> {
     return this.delete(`/tags/${id}`);
+  }
+
+  async updateTag(id: string, data: UpdateTagRequest): Promise<void> {
+    return this.patch(`/tags/${id}`, { json: data });
   }
 
   async tagImage(imageId: string, tagId: string): Promise<void> {

--- a/services/client/src/feature/Tag/TagDataTable/TagActionsCell.svelte
+++ b/services/client/src/feature/Tag/TagDataTable/TagActionsCell.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
-  import { TagDeletePopover } from '@slink/feature/Tag';
+  import { TagDeletePopover, TagMoveDialog } from '@slink/feature/Tag';
 
   import type { Tag } from '@slink/api/Resources/TagResource';
 
   interface Props {
     tag: Tag;
     onDelete: (tag: Tag) => Promise<void>;
+    onMove: (tag: Tag, parentId?: string | null) => Promise<void>;
   }
 
-  let { tag, onDelete }: Props = $props();
+  let { tag, onDelete, onMove }: Props = $props();
 </script>
 
 <div class="flex items-center justify-end gap-2 pr-2">
+  <TagMoveDialog {tag} {onMove} />
   <TagDeletePopover {tag} {onDelete} />
 </div>

--- a/services/client/src/feature/Tag/TagDataTable/TagDataTable.svelte
+++ b/services/client/src/feature/Tag/TagDataTable/TagDataTable.svelte
@@ -24,6 +24,7 @@
   interface Props {
     tags: Tag[];
     onDelete: (tag: Tag) => Promise<void>;
+    onMove: (tag: Tag, parentId?: string | null) => Promise<void>;
     searchTerm: string;
     onSearchChange: (term: string) => void;
     isLoading?: boolean;
@@ -39,6 +40,7 @@
   let {
     tags,
     onDelete,
+    onMove,
     searchTerm = $bindable(),
     onSearchChange,
     isLoading = false,
@@ -109,6 +111,7 @@
         return renderComponent(TagActionsCell, {
           tag,
           onDelete,
+          onMove,
         });
       },
     },

--- a/services/client/src/feature/Tag/TagDeleteConfirmation/TagDeletePopover.svelte
+++ b/services/client/src/feature/Tag/TagDeleteConfirmation/TagDeletePopover.svelte
@@ -18,56 +18,43 @@
 
   const hasImages = $derived(tag.imageCount > 0);
   const hasChildren = $derived(tag.children && tag.children.length > 0);
-  const canDelete = $derived(!hasImages && !hasChildren);
   const childrenCount = $derived(tag.children?.length || 0);
 
-  const title = $derived(canDelete ? 'Delete Tag' : 'Cannot Delete Tag');
+  const title = $derived('Delete Tag');
 
   const description = $derived.by(() => {
-    if (canDelete) {
-      return 'This action cannot be undone';
-    }
-
     if (hasImages && hasChildren) {
-      return `Tag has ${tag.imageCount} images and ${childrenCount} child tags`;
+      return `This will remove the tag from ${tag.imageCount} images and delete ${childrenCount} child tags.`;
     }
 
     if (hasImages) {
-      return `Tag has ${tag.imageCount} associated images`;
+      return `This will remove the tag from ${tag.imageCount} images.`;
     }
 
-    return `Tag has ${childrenCount} child tags`;
+    if (hasChildren) {
+      return `This will delete ${childrenCount} child tags.`;
+    }
+
+    return 'This action cannot be undone.';
   });
 
-  const confirmText = $derived(canDelete ? 'Delete Tag' : 'Understood');
-  const variant = $derived(canDelete ? 'danger' : 'warning');
-  const iconName = $derived(
-    canDelete ? 'heroicons:trash' : 'heroicons:exclamation-triangle',
-  );
+  const confirmText = $derived('Delete Tag');
+  const variant = $derived('danger');
+  const iconName = $derived('heroicons:trash');
   const iconBgColor = $derived(
-    canDelete
-      ? 'bg-red-100 dark:bg-red-900/30 border-red-200/40 dark:border-red-800/30'
-      : 'bg-amber-100 dark:bg-amber-900/30 border-amber-200/40 dark:border-amber-800/30',
+    'bg-red-100 dark:bg-red-900/30 border-red-200/40 dark:border-red-800/30',
   );
-  const iconColor = $derived(
-    canDelete
-      ? 'text-red-600 dark:text-red-400'
-      : 'text-amber-600 dark:text-amber-400',
-  );
+  const iconColor = $derived('text-red-600 dark:text-red-400');
 
   async function handleConfirm() {
-    if (canDelete) {
-      try {
-        isDeleting = true;
-        await onDelete(tag);
-        open = false;
-      } catch (error) {
-        console.error('Failed to delete tag:', error);
-      } finally {
-        isDeleting = false;
-      }
-    } else {
+    try {
+      isDeleting = true;
+      await onDelete(tag);
       open = false;
+    } catch (error) {
+      console.error('Failed to delete tag:', error);
+    } finally {
+      isDeleting = false;
     }
   }
 
@@ -109,21 +96,21 @@
         </div>
       </div>
 
-      {#if !canDelete}
+      {#if hasImages || hasChildren}
         <div
           class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/50 rounded-lg p-3"
         >
           <h4
             class="text-xs font-medium text-amber-800 dark:text-amber-200 mb-1"
           >
-            Before deleting this tag:
+            Deleting this tag will also:
           </h4>
           <ul class="text-xs text-amber-700 dark:text-amber-300 space-y-0.5">
             {#if hasImages}
-              <li>• Remove tag from all {tag.imageCount} images</li>
+              <li>• Remove tag from {tag.imageCount} images</li>
             {/if}
             {#if hasChildren}
-              <li>• Delete or move all {childrenCount} child tags</li>
+              <li>• Delete {childrenCount} child tags</li>
             {/if}
           </ul>
         </div>

--- a/services/client/src/feature/Tag/TagMoveDialog/TagMoveDialog.svelte
+++ b/services/client/src/feature/Tag/TagMoveDialog/TagMoveDialog.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { TagSelector } from '@slink/feature/Tag';
+  import { Button } from '@slink/ui/components/button';
+  import { Dialog } from '@slink/ui/components/dialog';
+
+  import Icon from '@iconify/svelte';
+
+  import type { Tag } from '@slink/api/Resources/TagResource';
+
+  import { getTagParentPath } from '@slink/lib/utils/tag';
+
+  interface Props {
+    tag: Tag;
+    onMove: (tag: Tag, parentId?: string | null) => Promise<void>;
+  }
+
+  let { tag, onMove }: Props = $props();
+
+  let open = $state(false);
+  let selectedParent = $state<Tag | null>(null);
+  let isSaving = $state(false);
+
+  const currentParentLabel = $derived(
+    getTagParentPath(tag) || 'Root',
+  );
+
+  const isMoveDisabled = $derived(
+    isSaving || (!selectedParent && tag.isRoot),
+  );
+
+  const handleMove = async () => {
+    if (isMoveDisabled) return;
+
+    try {
+      isSaving = true;
+      await onMove(tag, selectedParent?.id ?? null);
+      open = false;
+    } finally {
+      isSaving = false;
+    }
+  };
+
+  const handleMoveToRoot = () => {
+    selectedParent = null;
+  };
+
+  $effect(() => {
+    if (!open) {
+      selectedParent = null;
+      isSaving = false;
+    }
+  });
+</script>
+
+<button
+  type="button"
+  class="group relative flex items-center justify-center h-8 w-8 rounded-md bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm border border-gray-200/60 dark:border-gray-700/60 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-950/30 hover:border-blue-200 dark:hover:border-blue-800/50 active:scale-95 focus-visible:ring-blue-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 transition-all duration-200 ease-out"
+  aria-label="Move tag"
+  onclick={() => (open = true)}
+>
+  <Icon icon="ph:folder" class="h-4 w-4" />
+  <span class="sr-only">Move tag "{tag.name}"</span>
+</button>
+
+<Dialog bind:open size="md" variant="blue">
+  {#snippet children()}
+    <div class="space-y-4">
+      <div class="flex items-start gap-3">
+        <div
+          class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-900/30 border border-blue-200/40 dark:border-blue-800/30"
+        >
+          <Icon icon="ph:folder" class="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
+            Move Tag
+          </h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            Current parent: {currentParentLabel}
+          </p>
+        </div>
+      </div>
+
+      <TagSelector
+        selectedTags={selectedParent ? [selectedParent] : []}
+        onTagsChange={(tags) => (selectedParent = tags[0] ?? null)}
+        placeholder="Search and select parent tag"
+        variant="neon"
+        allowCreate={false}
+        singleSelect={true}
+        excludeTagIds={[tag.id]}
+        excludePathPrefix={tag.path}
+      />
+
+      <div class="rounded-lg bg-slate-50 dark:bg-slate-900/60 border border-slate-200/60 dark:border-slate-800/60 p-3 text-xs text-slate-600 dark:text-slate-300">
+        Moving this tag will also move its child tags under the new parent.
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <Button
+          variant="glass"
+          rounded="full"
+          size="sm"
+          onclick={() => (open = false)}
+          class="flex-1"
+          disabled={isSaving}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="outline"
+          rounded="full"
+          size="sm"
+          onclick={handleMoveToRoot}
+          class="flex-1"
+          disabled={isSaving || tag.isRoot}
+        >
+          Move to Root
+        </Button>
+        <Button
+          variant="primary"
+          rounded="full"
+          size="sm"
+          onclick={handleMove}
+          class="flex-1 font-medium shadow-lg hover:shadow-xl transition-all duration-200"
+          disabled={isMoveDisabled}
+        >
+          {#if isSaving}
+            <Icon icon="eos-icons:three-dots-loading" class="h-4 w-4 mr-2" />
+          {:else}
+            <Icon icon="ph:arrow-right" class="h-4 w-4 mr-2" />
+          {/if}
+          Move Tag
+        </Button>
+      </div>
+    </div>
+  {/snippet}
+</Dialog>

--- a/services/client/src/feature/Tag/TagMoveDialog/index.ts
+++ b/services/client/src/feature/Tag/TagMoveDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TagMoveDialog.svelte';

--- a/services/client/src/feature/Tag/TagSelector/TagSelector.svelte
+++ b/services/client/src/feature/Tag/TagSelector/TagSelector.svelte
@@ -27,6 +27,8 @@
     allowCreate?: boolean;
     hideIcon?: boolean;
     singleSelect?: boolean;
+    excludeTagIds?: string[];
+    excludePathPrefix?: string;
   }
 
   let {
@@ -38,6 +40,8 @@
     allowCreate = true,
     hideIcon = false,
     singleSelect = false,
+    excludeTagIds = [],
+    excludePathPrefix,
   }: Props = $props();
 
   let isOpen = $state(false);
@@ -54,6 +58,7 @@
 
   const hasSelectedTags = $derived(selectedTags.length > 0);
   const selectedTagIds = $derived(new Set(selectedTags.map((tag) => tag.id)));
+  const excludedTagIds = $derived(new Set(excludeTagIds));
 
   const {
     loadTags,
@@ -72,11 +77,19 @@
   const shouldShowLoader = $derived($isLoadingTags && !!searchTerm?.trim());
 
   const filteredTags = $derived(
-    availableTags.filter(
-      (tag: Tag) =>
-        !selectedTagIds.has(tag.id) &&
-        tag.name.toLowerCase().includes(searchTerm.toLowerCase()),
-    ),
+    availableTags.filter((tag: Tag) => {
+      if (selectedTagIds.has(tag.id)) return false;
+      if (excludedTagIds.has(tag.id)) return false;
+      if (
+        excludePathPrefix &&
+        (tag.path === excludePathPrefix ||
+          tag.path.startsWith(`${excludePathPrefix}/`))
+      ) {
+        return false;
+      }
+
+      return tag.name.toLowerCase().includes(searchTerm.toLowerCase());
+    }),
   );
 
   const canCreate = $derived(

--- a/services/client/src/feature/Tag/index.ts
+++ b/services/client/src/feature/Tag/index.ts
@@ -11,6 +11,7 @@ export { default as TagDataTable } from './TagDataTable/TagDataTable.svelte';
 export { default as TagNameCell } from './TagDataTable/TagNameCell.svelte';
 export * from './TagDataTable/types';
 export { default as TagDeletePopover } from './TagDeleteConfirmation/TagDeletePopover.svelte';
+export { default as TagMoveDialog } from './TagMoveDialog/TagMoveDialog.svelte';
 export { default as TagDepthDots } from './TagDepthDots/TagDepthDots.svelte';
 export { default as TagDepthIndicator } from './TagDepthIndicator/TagDepthIndicator.svelte';
 export { default as TagDropdown } from './TagDropdown/TagDropdown.svelte';

--- a/services/client/src/lib/state/TagListFeed.svelte.ts
+++ b/services/client/src/lib/state/TagListFeed.svelte.ts
@@ -4,6 +4,7 @@ import type {
   Tag,
   TagListRequest,
   TagListingResponse,
+  UpdateTagRequest,
 } from '@slink/api/Resources/TagResource';
 
 import { AbstractPaginatedFeed } from '@slink/lib/state/core/AbstractPaginatedFeed.svelte';
@@ -177,6 +178,28 @@ class TagListFeed extends AbstractPaginatedFeed<Tag> {
       const message = extractErrorMessage(
         error,
         'Failed to delete tag. Please try again.',
+      );
+      toast.error(message);
+      throw error;
+    }
+  }
+
+  async moveTag(id: string, parentId?: string | null): Promise<void> {
+    try {
+      const tag = this._items.find((item) => item.id === id);
+      const tagName = tag?.name || 'tag';
+
+      const payload: UpdateTagRequest = {
+        parentId: parentId ?? null,
+      };
+
+      await ApiClient.tag.updateTag(id, payload);
+      toast.success(`Tag "${tagName}" moved successfully`);
+      await this.refetch();
+    } catch (error: any) {
+      const message = extractErrorMessage(
+        error,
+        'Failed to move tag. Please try again.',
       );
       toast.error(message);
       throw error;

--- a/services/client/src/routes/tags/+page.svelte
+++ b/services/client/src/routes/tags/+page.svelte
@@ -50,6 +50,10 @@
     await tagFeed.deleteTag(tag.id);
   }
 
+  async function handleMoveTag(tag: Tag, parentId?: string | null) {
+    await tagFeed.moveTag(tag.id, parentId);
+  }
+
   function handleCreateTag() {
     createModalState.open(() => {
       tagFeed.refetch();
@@ -105,6 +109,7 @@
       <TagDataTable
         tags={tagFeed.data}
         onDelete={handleDeleteTag}
+        onMove={handleMoveTag}
         bind:searchTerm={searchQuery}
         onSearchChange={handleSearchChange}
         isLoading={tagFeed.loading}


### PR DESCRIPTION
  Summary
  - Add API support to move a tag under a different parent while preserving metadata and relationships.
  - Add cascade delete to remove a tag and all descendants cleanly.

https://github.com/andrii-kryvoviaz/slink/issues/148