### PR TITLE
feat: Run Frankenphp with no capabilities

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -19,7 +19,8 @@ RUN rm -rf /usr/src/php* \
         /usr/local/lib/php/build \
         /usr/local/bin/phpdbg \
         /usr/local/bin/php-cgi \
-        /tmp/* /var/cache/apk/*
+        /tmp/* /var/cache/apk/* \
+    && setcap -r /usr/local/bin/frankenphp
 
 FROM frankenphp-upstream AS php-extensions
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/


### PR DESCRIPTION
With all capabilities removed, Frankenphp can be run directly by non-privileged users. Useful for those who run containers without the s6-overlay.

Official documentation:
- https://github.com/php/frankenphp/blob/main/docs/docker.md#running-as-a-non-root-user