### PR TITLE
Fix dark mode sidebar scrollbar styling

### DIFF
--- a/services/client/src/theme/theme.sidebar.css
+++ b/services/client/src/theme/theme.sidebar.css
@@ -30,8 +30,10 @@
   }
 
   .sidebar-scrollbar {
+    --sidebar-scrollbar-thumb: color-mix(in oklch, var(--muted-foreground) 20%, transparent);
+    --sidebar-scrollbar-thumb-hover: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
     scrollbar-width: thin;
-    scrollbar-color: hsl(var(--muted-foreground) / 0.2) transparent;
+    scrollbar-color: var(--sidebar-scrollbar-thumb) transparent;
   }
 
   .sidebar-scrollbar::-webkit-scrollbar {
@@ -44,13 +46,13 @@
   }
 
   .sidebar-scrollbar::-webkit-scrollbar-thumb {
-    background-color: hsl(var(--muted-foreground) / 0.2);
+    background-color: var(--sidebar-scrollbar-thumb);
     border-radius: 3px;
     transition: background-color 0.2s ease;
   }
 
   .sidebar-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: hsl(var(--muted-foreground) / 0.3);
+    background-color: var(--sidebar-scrollbar-thumb-hover);
   }
 
   .focus-ring {

--- a/services/client/src/ui/components/sidebar/sidebar-content.svelte
+++ b/services/client/src/ui/components/sidebar/sidebar-content.svelte
@@ -16,7 +16,7 @@
   data-slot="sidebar-content"
   data-sidebar="content"
   class={cn(
-    'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+    'sidebar-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
     className,
   )}
   {...restProps}


### PR DESCRIPTION
Vibe-coded a small fix for the dark mode sidebar scrollbar: apply the existing `sidebar-scrollbar` class to the actual sidebar content element and use OKLCH-compatible `color-mix(...)` for the thumb colors.

<img width="1000" height="320" alt="image" src="https://github.com/user-attachments/assets/1fc56f4e-cf8d-415e-aef0-744ddfb24635" />
